### PR TITLE
Replace grid lines with intersection dots

### DIFF
--- a/src/renderer/src/components/file-renderer.tsx
+++ b/src/renderer/src/components/file-renderer.tsx
@@ -197,6 +197,7 @@ const FileRendererInner = memo(
           gridWidthUv: { value: 0.0 },
           gridHeightUv: { value: 0.0 },
           barWidthUv: { value: 0.0 },
+          octaveHeightUv: { value: 0.0 },
           showHorizontalGrid: { value: true },
           showVerticalGrid: { value: true },
           showTargetRectangle: { value: false },
@@ -665,6 +666,7 @@ const FileRendererInner = memo(
       const bandsPerSemitone = spectrogramData.bandsPerOctave / 12;
       const gridIntervalBands = gridSizeSemis * bandsPerSemitone;
       const gridHeightUv = gridSizeSemis > 0 ? gridIntervalBands / spectrogramData.numBands : 0;
+      const octaveHeightUv = gridSizeSemis > 0 ? (12 * bandsPerSemitone) / spectrogramData.numBands : 0;
 
       // Determine if grid lines should be shown based on spacing (min 10 pixels apart)
       const MIN_GRID_SPACING_PX = 10;
@@ -676,6 +678,7 @@ const FileRendererInner = memo(
       displayMaterial.uniforms.gridWidthUv.value = gridWidthUv;
       displayMaterial.uniforms.gridHeightUv.value = gridHeightUv;
       displayMaterial.uniforms.barWidthUv.value = barWidthUv;
+      displayMaterial.uniforms.octaveHeightUv.value = octaveHeightUv;
       displayMaterial.uniforms.showHorizontalGrid.value = gridWidthPx >= MIN_GRID_SPACING_PX && gridSizeBeats > 0;
       displayMaterial.uniforms.showVerticalGrid.value = gridHeightPx >= MIN_GRID_SPACING_PX && gridSizeSemis > 0;
 

--- a/src/renderer/src/glsl/display.frag
+++ b/src/renderer/src/glsl/display.frag
@@ -87,16 +87,20 @@ void main() {
         color = leftColor + rightColor;
     }
 
-    // Grid dots at beat x semitone intersections
-    if (showHorizontalGrid && showVerticalGrid && gridWidthUv > 0.0 && gridHeightUv > 0.0) {
+    // Grid dots. Dots land at beat x semitone crossings; if only one axis has
+    // a grid, the other is synthesized at a fixed pixel spacing so dots still
+    // appear.
+    if (showHorizontalGrid || showVerticalGrid) {
         float hThick = fwidth(zoomedUv.x);
         float vThick = fwidth(zoomedUv.y);
-        float hLine = mod(zoomedUv.x, gridWidthUv);
-        float vLine = mod(zoomedUv.y, gridHeightUv);
+        float hSpacing = showHorizontalGrid ? gridWidthUv : 24.0 * hThick;
+        float vSpacing = showVerticalGrid ? gridHeightUv : 24.0 * vThick;
+        float hLine = mod(zoomedUv.x, hSpacing);
+        float vLine = mod(zoomedUv.y, vSpacing);
 
         if (hLine < hThick && vLine < vThick) {
-            bool isBar = mod(zoomedUv.x, barWidthUv) < hThick;
-            bool isOctave = octaveHeightUv > 0.0 && mod(zoomedUv.y, octaveHeightUv) < vThick;
+            bool isBar = !showHorizontalGrid || mod(zoomedUv.x, barWidthUv) < hThick;
+            bool isOctave = !showVerticalGrid || (octaveHeightUv > 0.0 && mod(zoomedUv.y, octaveHeightUv) < vThick);
             float delta = (isBar && isOctave) ? 0.5 : 0.3;
             color = mix(color + delta, color - delta, step(1.0 - delta, color));
         }

--- a/src/renderer/src/glsl/display.frag
+++ b/src/renderer/src/glsl/display.frag
@@ -18,6 +18,7 @@ uniform vec2 sourceSamplingBottomLeftUv; // Pre-computed sampling position on th
 uniform float gridWidthUv;        // Width of each beat in UV coordinates
 uniform float gridHeightUv;       // Height of each semitone in UV coordinates
 uniform float barWidthUv;         // Width of each bar (4 beats) in UV coordinates
+uniform float octaveHeightUv;     // Height of one octave in UV coordinates
 uniform bool showHorizontalGrid;  // Whether to show horizontal grid lines
 uniform bool showVerticalGrid;    // Whether to show vertical grid lines
 
@@ -86,29 +87,18 @@ void main() {
         color = leftColor + rightColor;
     }
 
-    // Grid lines (in zoomed coordinates)
-    float lineThicknessUv = fwidth(zoomedUv.x);
-    
-    // Horizontal grid lines (time)
-    if (showHorizontalGrid) {
-        float line = mod(zoomedUv.x, gridWidthUv);
-        
-        // Check if this is the first beat of a bar (4/4 timing)
-        float barLine = mod(zoomedUv.x, barWidthUv);
-        bool isBarStart = barLine < gridWidthUv;
-        
-        if (line < lineThicknessUv) {
-            color = fract(color + 0.3);
-        }
-    }
-    
-    // Vertical grid lines (frequency)
-    if (showVerticalGrid && gridHeightUv > 0.0) {
-        float verticalLine = mod(zoomedUv.y, gridHeightUv);
-        float verticalLineThicknessUv = fwidth(zoomedUv.y);
-        
-        if (verticalLine < verticalLineThicknessUv) {
-            color = fract(color + 0.3);
+    // Grid dots at beat x semitone intersections
+    if (showHorizontalGrid && showVerticalGrid && gridWidthUv > 0.0 && gridHeightUv > 0.0) {
+        float hThick = fwidth(zoomedUv.x);
+        float vThick = fwidth(zoomedUv.y);
+        float hLine = mod(zoomedUv.x, gridWidthUv);
+        float vLine = mod(zoomedUv.y, gridHeightUv);
+
+        if (hLine < hThick && vLine < vThick) {
+            bool isBar = mod(zoomedUv.x, barWidthUv) < hThick;
+            bool isOctave = octaveHeightUv > 0.0 && mod(zoomedUv.y, octaveHeightUv) < vThick;
+            float delta = (isBar && isOctave) ? 0.5 : 0.3;
+            color = mix(color + delta, color - delta, step(1.0 - delta, color));
         }
     }
 


### PR DESCRIPTION
1px dots at each beat x semitone crossing, with stronger contrast at
bar x octave crossings. Uses adaptive contrast (brighten by delta, or
darken if that would clip past 1.0) so dots stay visible on any
background, including pure white.

https://claude.ai/code/session_01ACk3VabvCJfdDpPn7c4cm8