### PR TITLE
✨ NMF separation and linked stem groups that merge back together

### DIFF
--- a/gaborator-addon.cpp
+++ b/gaborator-addon.cpp
@@ -1099,6 +1099,431 @@ Napi::Value HpssAsync(const Napi::CallbackInfo &info)
     return promise;
 }
 
+// ─── NMF separation ──────────────────────────────────────────────────────────
+//
+// Factorises the magnitude spectrogram as V ≈ W·H, where W holds `numComponents`
+// spectral templates and H their activations over time, then turns each
+// component's reconstruction into a Wiener soft mask. Like HPSS the masks are
+// applied to the magnitude channels only and sum to 1 across components, so the
+// parts add back up to the input — phase channels are copied through untouched.
+//
+// Gaborator's layout is multirate (each band has its own frame count), so the
+// factorisation runs on a rectangular matrix built by resampling every band onto
+// a shared normalised time grid. Masks are then evaluated at each band's native
+// rate by interpolating H, which keeps the fit cheap without losing resolution
+// in the output.
+
+// Longest band length used for the fit grid. Beyond this the extra temporal
+// detail costs iterations without changing the templates meaningfully.
+#define NMF_MAX_FIT_FRAMES 2048
+
+// Deterministic PRNG (LCG) so a given seed always yields the same factorisation.
+static inline float nmfRandom(uint32_t &state)
+{
+    state = state * 1664525u + 1013904223u;
+    return (float)((state >> 8) & 0xFFFFFFu) / (float)0x1000000;
+}
+
+class NmfWorker : public Napi::AsyncWorker
+{
+public:
+    NmfWorker(Napi::Env env,
+              Napi::Float32Array packedDataJs,
+              Napi::Object metaJs,
+              int numComponents, int iterations, uint32_t seed)
+        : Napi::AsyncWorker(env),
+          deferred(Napi::Promise::Deferred::New(env)),
+          numComponents(numComponents), iterations(iterations), seed(seed)
+    {
+        packedData.assign(packedDataJs.Data(),
+                          packedDataJs.Data() + packedDataJs.ElementLength());
+
+        numBands    = metaJs.Get("numBands").As<Napi::Number>().Int32Value();
+        numChannels = metaJs.Get("numChannels").As<Napi::Number>().Int32Value();
+
+        Napi::Uint32Array bo = metaJs.Get("bandOffsets").As<Napi::Uint32Array>();
+        bandOffsets.assign(bo.Data(), bo.Data() + bo.ElementLength());
+
+        Napi::Uint32Array bl = metaJs.Get("bandLengths").As<Napi::Uint32Array>();
+        bandLengths.assign(bl.Data(), bl.Data() + bl.ElementLength());
+    }
+
+    Napi::Promise GetPromise() { return deferred.Promise(); }
+
+    void Execute() override
+    {
+        const int floatsPerPixel = 4;
+        const float eps = 1e-10f;
+        const int K = numComponents;
+
+        int maxLen = 0;
+        for (int b = 0; b < numBands; ++b)
+            maxLen = std::max(maxLen, (int)bandLengths[b]);
+        const int T = std::max(1, std::min(maxLen, NMF_MAX_FIT_FRAMES));
+
+        // V [numBands × T]: magnitudes summed over channels so one factorisation
+        // describes both, keeping component k the same sound in left and right.
+        std::vector<float> V((size_t)numBands * T, 0.0f);
+        for (int b = 0; b < numBands; ++b)
+        {
+            const int L = (int)bandLengths[b];
+            for (int t = 0; t < T; ++t)
+            {
+                const float normTime = (T > 1) ? (float)t / (float)(T - 1) : 0.0f;
+                const int st = (L > 1)
+                                   ? std::min((int)std::lround(normTime * (float)(L - 1)), L - 1)
+                                   : 0;
+                float sum = 0.0f;
+                for (int ch = 0; ch < numChannels; ++ch)
+                    sum += packedData[((size_t)bandOffsets[b] + st) * floatsPerPixel + ch * 2];
+                V[(size_t)b * T + t] = sum;
+            }
+        }
+
+        uint32_t rng = seed ? seed : 1u;
+        std::vector<float> W((size_t)numBands * K), H((size_t)K * T);
+        for (auto &w : W) w = nmfRandom(rng) * 0.9f + 0.1f;
+        for (auto &h : H) h = nmfRandom(rng) * 0.9f + 0.1f;
+
+        std::vector<float> WH((size_t)numBands * T);
+        std::vector<float> ratio((size_t)numBands * T);
+        std::vector<float> hAcc((size_t)K * T);
+        std::vector<float> hSum(K), wSum(K);
+
+        // Multiplicative updates for the KL divergence, which tracks the wide
+        // dynamic range of a constant-Q magnitude spectrum better than the
+        // Euclidean variant does.
+        for (int it = 0; it < iterations; ++it)
+        {
+            for (int b = 0; b < numBands; ++b)
+            {
+                float *out = &WH[(size_t)b * T];
+                std::fill(out, out + T, 0.0f);
+                for (int k = 0; k < K; ++k)
+                {
+                    const float w = W[(size_t)b * K + k];
+                    if (w <= 0.0f) continue;
+                    const float *hrow = &H[(size_t)k * T];
+                    for (int t = 0; t < T; ++t) out[t] += w * hrow[t];
+                }
+            }
+            for (size_t i = 0; i < WH.size(); ++i)
+                ratio[i] = V[i] / (WH[i] + eps);
+
+            // H ← H ⊙ (Wᵀ·ratio) / (Wᵀ·1)
+            std::fill(hAcc.begin(), hAcc.end(), 0.0f);
+            std::fill(wSum.begin(), wSum.end(), 0.0f);
+            for (int b = 0; b < numBands; ++b)
+            {
+                const float *rrow = &ratio[(size_t)b * T];
+                for (int k = 0; k < K; ++k)
+                {
+                    const float w = W[(size_t)b * K + k];
+                    wSum[k] += w;
+                    if (w <= 0.0f) continue;
+                    float *arow = &hAcc[(size_t)k * T];
+                    for (int t = 0; t < T; ++t) arow[t] += w * rrow[t];
+                }
+            }
+            for (int k = 0; k < K; ++k)
+            {
+                float *hrow = &H[(size_t)k * T];
+                const float *arow = &hAcc[(size_t)k * T];
+                const float denom = wSum[k] + eps;
+                for (int t = 0; t < T; ++t) hrow[t] *= arow[t] / denom;
+            }
+
+            // W ← W ⊙ (ratio·Hᵀ) / (1·Hᵀ), using the ratio from the same sweep;
+            // recomputing WH between the two halves costs a full pass for a
+            // convergence difference that isn't audible.
+            for (int k = 0; k < K; ++k)
+            {
+                const float *hrow = &H[(size_t)k * T];
+                float s = 0.0f;
+                for (int t = 0; t < T; ++t) s += hrow[t];
+                hSum[k] = s;
+            }
+            for (int b = 0; b < numBands; ++b)
+            {
+                const float *rrow = &ratio[(size_t)b * T];
+                for (int k = 0; k < K; ++k)
+                {
+                    const float *hrow = &H[(size_t)k * T];
+                    float s = 0.0f;
+                    for (int t = 0; t < T; ++t) s += rrow[t] * hrow[t];
+                    W[(size_t)b * K + k] *= s / (hSum[k] + eps);
+                }
+            }
+        }
+
+        // Normalise each template to unit sum, pushing the scale into its
+        // activations so W·H is unchanged but the columns are comparable.
+        for (int k = 0; k < K; ++k)
+        {
+            float colSum = 0.0f;
+            for (int b = 0; b < numBands; ++b) colSum += W[(size_t)b * K + k];
+            if (colSum <= eps) continue;
+            for (int b = 0; b < numBands; ++b) W[(size_t)b * K + k] /= colSum;
+            float *hrow = &H[(size_t)k * T];
+            for (int t = 0; t < T; ++t) hrow[t] *= colSum;
+        }
+
+        // Order components by spectral centroid so part 1 is the lowest-pitched.
+        // The factorisation itself has no canonical ordering, and low→high reads
+        // naturally against the vertical spectrogram.
+        std::vector<int> order(K);
+        std::iota(order.begin(), order.end(), 0);
+        std::vector<float> centroid(K, 0.0f);
+        for (int k = 0; k < K; ++k)
+        {
+            float num = 0.0f, den = 0.0f;
+            for (int b = 0; b < numBands; ++b)
+            {
+                const float w = W[(size_t)b * K + k];
+                num += (float)b * w;
+                den += w;
+            }
+            centroid[k] = (den > eps) ? num / den : 0.0f;
+        }
+        std::sort(order.begin(), order.end(),
+                  [&](int a, int b) { return centroid[a] < centroid[b]; });
+
+        // Wiener masks at each band's native frame rate, with H interpolated
+        // back up from the fit grid. Phase channels stay as they are.
+        parts.assign(K, packedData);
+        std::vector<float> comp(K);
+        for (int b = 0; b < numBands; ++b)
+        {
+            const int L = (int)bandLengths[b];
+            for (int t = 0; t < L; ++t)
+            {
+                const float pos = (L > 1)
+                                      ? ((float)t / (float)(L - 1)) * (float)(T - 1)
+                                      : 0.0f;
+                const int t0 = std::min((int)pos, T - 1);
+                const int t1 = std::min(t0 + 1, T - 1);
+                const float frac = pos - (float)t0;
+
+                float total = 0.0f;
+                for (int k = 0; k < K; ++k)
+                {
+                    const int src = order[k];
+                    const float h = H[(size_t)src * T + t0] * (1.0f - frac) +
+                                    H[(size_t)src * T + t1] * frac;
+                    const float v = W[(size_t)b * K + src] * h;
+                    comp[k] = v * v;
+                    total += comp[k];
+                }
+                total += eps;
+
+                for (int ch = 0; ch < numChannels; ++ch)
+                {
+                    const size_t fi = ((size_t)bandOffsets[b] + t) * floatsPerPixel + ch * 2;
+                    const float mag = packedData[fi];
+                    for (int k = 0; k < K; ++k)
+                        parts[k][fi] = mag * (comp[k] / total);
+                }
+            }
+        }
+    }
+
+    void OnOK() override
+    {
+        Napi::Env env = Env();
+        Napi::Array partsJs = Napi::Array::New(env, parts.size());
+        for (size_t k = 0; k < parts.size(); ++k)
+        {
+            Napi::Float32Array arr = Napi::Float32Array::New(env, parts[k].size());
+            memcpy(arr.Data(), parts[k].data(), parts[k].size() * sizeof(float));
+            partsJs[(uint32_t)k] = arr;
+        }
+        Napi::Object result = Napi::Object::New(env);
+        result.Set("parts", partsJs);
+        deferred.Resolve(result);
+    }
+
+    void OnError(const Napi::Error &e) override { deferred.Reject(e.Value()); }
+
+private:
+    Napi::Promise::Deferred deferred;
+    std::vector<float> packedData;
+    std::vector<std::vector<float>> parts;
+    std::vector<uint32_t> bandOffsets, bandLengths;
+    int numComponents, iterations;
+    uint32_t seed;
+    int numBands = 0, numChannels = 0;
+};
+
+Napi::Value NmfAsync(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+    if (info.Length() < 3 || !info[0].IsTypedArray() || !info[1].IsObject() || !info[2].IsNumber())
+    {
+        Napi::TypeError::New(env,
+            "Expected (Float32Array packedData, Object meta, number numComponents[, number iterations, number seed])")
+            .ThrowAsJavaScriptException();
+        return env.Null();
+    }
+    const int numComponents = std::max(2, info[2].As<Napi::Number>().Int32Value());
+    const int iterations = (info.Length() > 3 && info[3].IsNumber())
+                               ? std::max(1, info[3].As<Napi::Number>().Int32Value())
+                               : 120;
+    const uint32_t seed = (info.Length() > 4 && info[4].IsNumber())
+                              ? (uint32_t)info[4].As<Napi::Number>().Int64Value()
+                              : 1u;
+
+    auto *worker = new NmfWorker(env,
+        info[0].As<Napi::Float32Array>(),
+        info[1].As<Napi::Object>(),
+        numComponents, iterations, seed);
+    auto promise = worker->GetPromise();
+    worker->Queue();
+    return promise;
+}
+
+// ─── Spectrogram merge ───────────────────────────────────────────────────────
+//
+// Sums several spectrograms that share a band layout. The sum is taken on the
+// complex coefficients, not the magnitudes: parts fresh out of a split share the
+// input's phase and would add correctly either way, but once a part has been
+// edited (the transform effect rewrites phase) magnitude addition overlaps
+// incoherently and reads as too loud in the shared bins.
+
+class MergeWorker : public Napi::AsyncWorker
+{
+public:
+    MergeWorker(Napi::Env env, Napi::Array inputsJs, Napi::Object metaJs)
+        : Napi::AsyncWorker(env),
+          deferred(Napi::Promise::Deferred::New(env))
+    {
+        const uint32_t count = inputsJs.Length();
+        inputs.resize(count);
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            Napi::Float32Array arr = inputsJs.Get(i).As<Napi::Float32Array>();
+            inputs[i].assign(arr.Data(), arr.Data() + arr.ElementLength());
+        }
+
+        numBands    = metaJs.Get("numBands").As<Napi::Number>().Int32Value();
+        numChannels = metaJs.Get("numChannels").As<Napi::Number>().Int32Value();
+
+        Napi::Uint32Array bo = metaJs.Get("bandOffsets").As<Napi::Uint32Array>();
+        bandOffsets.assign(bo.Data(), bo.Data() + bo.ElementLength());
+
+        Napi::Uint32Array bl = metaJs.Get("bandLengths").As<Napi::Uint32Array>();
+        bandLengths.assign(bl.Data(), bl.Data() + bl.ElementLength());
+    }
+
+    Napi::Promise GetPromise() { return deferred.Promise(); }
+
+    void Execute() override
+    {
+        if (inputs.empty())
+        {
+            SetError("mergeSpectrograms needs at least one input");
+            return;
+        }
+        const size_t len = inputs[0].size();
+        for (const auto &in : inputs)
+        {
+            if (in.size() != len)
+            {
+                SetError("mergeSpectrograms inputs must all be the same length");
+                return;
+            }
+        }
+
+        const int floatsPerPixel = 4;
+        merged.assign(len, 0.0f);
+
+        for (int b = 0; b < numBands; ++b)
+        {
+            const int L = (int)bandLengths[b];
+            for (int t = 0; t < L; ++t)
+            {
+                for (int ch = 0; ch < numChannels; ++ch)
+                {
+                    const size_t fi = ((size_t)bandOffsets[b] + t) * floatsPerPixel + ch * 2;
+                    if (fi + 1 >= len) continue;
+
+                    double re = 0.0, im = 0.0;
+                    // The part contributing most of the magnitude decides which
+                    // branch the result is expressed on.
+                    float refPhase = inputs[0][fi + 1];
+                    float bestMag = -1.0f;
+                    for (const auto &in : inputs)
+                    {
+                        const float mag = in[fi];
+                        const float phase = in[fi + 1];
+                        re += (double)mag * std::cos((double)phase);
+                        im += (double)mag * std::sin((double)phase);
+                        if (mag > bestMag)
+                        {
+                            bestMag = mag;
+                            refPhase = phase;
+                        }
+                    }
+
+                    const double mag = std::sqrt(re * re + im * im);
+                    merged[fi] = (float)mag;
+                    if (mag > 0.0)
+                    {
+                        // analyze() unwraps phase along time and the transform
+                        // effect's maths depends on that convention, so re-express
+                        // the summed angle on the reference's branch rather than
+                        // leaving it inside atan2's [-π, π]. Parts that still
+                        // share a phase come back with it bit-for-bit.
+                        const double raw = std::atan2(im, re);
+                        const double delta = std::remainder(raw - (double)refPhase, 2.0 * M_PI);
+                        merged[fi + 1] = (float)((double)refPhase + delta);
+                    }
+                    else
+                    {
+                        // A silent bin has no meaningful angle; keep the
+                        // reference phase so the field stays continuous.
+                        merged[fi + 1] = refPhase;
+                    }
+                }
+            }
+        }
+    }
+
+    void OnOK() override
+    {
+        Napi::Env env = Env();
+        Napi::Float32Array arr = Napi::Float32Array::New(env, merged.size());
+        memcpy(arr.Data(), merged.data(), merged.size() * sizeof(float));
+        Napi::Object result = Napi::Object::New(env);
+        result.Set("merged", arr);
+        deferred.Resolve(result);
+    }
+
+    void OnError(const Napi::Error &e) override { deferred.Reject(e.Value()); }
+
+private:
+    Napi::Promise::Deferred deferred;
+    std::vector<std::vector<float>> inputs;
+    std::vector<float> merged;
+    std::vector<uint32_t> bandOffsets, bandLengths;
+    int numBands = 0, numChannels = 0;
+};
+
+Napi::Value MergeSpectrogramsAsync(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+    if (info.Length() < 2 || !info[0].IsArray() || !info[1].IsObject())
+    {
+        Napi::TypeError::New(env, "Expected (Float32Array[] parts, Object meta)")
+            .ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    auto *worker = new MergeWorker(env, info[0].As<Napi::Array>(), info[1].As<Napi::Object>());
+    auto promise = worker->GetPromise();
+    worker->Queue();
+    return promise;
+}
+
 // ─── AI Separation (macOS arm64 only, via ONNX Runtime C++) ─────────────────
 
 #ifdef GABORATOR_ONNX_ENABLED
@@ -1416,6 +1841,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports)
     exports.Set("synthesize", Napi::Function::New(env, SynthesizeAsync));
     exports.Set("applyLimiter", Napi::Function::New(env, ApplyLimiterTest));
     exports.Set("hpss", Napi::Function::New(env, HpssAsync));
+    exports.Set("nmf", Napi::Function::New(env, NmfAsync));
+    exports.Set("mergeSpectrograms", Napi::Function::New(env, MergeSpectrogramsAsync));
 #ifdef GABORATOR_ONNX_ENABLED
     exports.Set("aiSeparate", Napi::Function::New(env, AiSeparateAsync));
 #endif

--- a/src/main/lib/__tests__/separation.test.ts
+++ b/src/main/lib/__tests__/separation.test.ts
@@ -1,0 +1,336 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { GaboratorAnalysisResult } from "../types";
+
+// Exercises the coefficient-domain separators against real Gaborator output.
+// The property that matters for both is conservation: NMF's masks sum to 1
+// across parts and leave phase alone, so the parts add back up to what they
+// were split from, and mergeSpectrograms is what adds them up. Everything here
+// runs on a spectrogram produced by the addon's own analyze() rather than a
+// hand-built buffer, so the band layout the maskers walk is the real one.
+
+const require = createRequire(import.meta.url);
+
+type BandLayout = {
+  numBands: number;
+  numChannels: number;
+  bandOffsets: Uint32Array;
+  bandLengths: Uint32Array;
+};
+
+const addon = require(join(__dirname, "../../../../build/Release/gaborator_addon.node")) as {
+  analyze: (
+    channels: Float32Array[],
+    numChannels: number,
+    sampleRate: number,
+    params: { bandsPerOctave: number; minFreq: number },
+  ) => Promise<GaboratorAnalysisResult>;
+  nmf: (
+    packedData: Float32Array,
+    meta: BandLayout,
+    numComponents: number,
+    iterations?: number,
+    seed?: number,
+  ) => Promise<{ parts: Float32Array[] }>;
+  mergeSpectrograms: (parts: Float32Array[], meta: BandLayout) => Promise<{ merged: Float32Array }>;
+  hpss: (
+    packedData: Float32Array,
+    meta: BandLayout,
+    kernelH?: number,
+    kernelV?: number,
+  ) => Promise<{ harmonic: Float32Array; percussive: Float32Array }>;
+};
+
+const SR = 44100;
+const DURATION = 1.0;
+const FLOATS_PER_PIXEL = 4;
+// The addon walks every coefficient of a real analysis, so each case is well
+// past vitest's 5 s default.
+const TIMEOUT = 120_000;
+
+/**
+ * A low sustained tone plus a high one that pulses, in stereo. Two sources this
+ * far apart in both frequency and time envelope is the case NMF should have no
+ * trouble pulling apart.
+ */
+function makeTwoSourceSignal(): Float32Array[] {
+  const length = Math.floor(SR * DURATION);
+  const left = new Float32Array(length);
+  const right = new Float32Array(length);
+  for (let i = 0; i < length; i++) {
+    const t = i / SR;
+    const low = 0.4 * Math.sin(2 * Math.PI * 220 * t);
+    // Eight bursts of a high tone, so its activation is distinct in time.
+    const gate = Math.floor(t * 8) % 2 === 0 ? 1 : 0;
+    const high = 0.3 * gate * Math.sin(2 * Math.PI * 3520 * t);
+    left[i] = low + high;
+    right[i] = low + high;
+  }
+  return [left, right];
+}
+
+/** Smallest signed angle congruent to `radians`, for comparing unwrapped phases. */
+function wrapToPi(radians: number): number {
+  return radians - 2 * Math.PI * Math.round(radians / (2 * Math.PI));
+}
+
+/** Walk every coefficient the band layout actually stores. */
+function forEachCoefficient(meta: BandLayout, visit: (magIndex: number) => void): void {
+  for (let b = 0; b < meta.numBands; b++) {
+    const length = meta.bandLengths[b];
+    for (let t = 0; t < length; t++) {
+      for (let ch = 0; ch < meta.numChannels; ch++) {
+        visit((meta.bandOffsets[b] + t) * FLOATS_PER_PIXEL + ch * 2);
+      }
+    }
+  }
+}
+
+/** Total magnitude a spectrogram holds, per band — used to see where a part's energy sits. */
+function bandEnergies(packed: Float32Array, meta: BandLayout): number[] {
+  const energies = new Array<number>(meta.numBands).fill(0);
+  for (let b = 0; b < meta.numBands; b++) {
+    const length = meta.bandLengths[b];
+    for (let t = 0; t < length; t++) {
+      for (let ch = 0; ch < meta.numChannels; ch++) {
+        energies[b] += packed[(meta.bandOffsets[b] + t) * FLOATS_PER_PIXEL + ch * 2];
+      }
+    }
+  }
+  return energies;
+}
+
+/** Magnitude-weighted mean band index: where a part sits in the spectrum. */
+function spectralCentroid(packed: Float32Array, meta: BandLayout): number {
+  const energies = bandEnergies(packed, meta);
+  let num = 0;
+  let den = 0;
+  for (let b = 0; b < meta.numBands; b++) {
+    num += b * energies[b];
+    den += energies[b];
+  }
+  return den > 0 ? num / den : 0;
+}
+
+describe("coefficient-domain separation", () => {
+  let analysis: GaboratorAnalysisResult;
+  let meta: BandLayout;
+
+  beforeAll(async () => {
+    analysis = await addon.analyze(makeTwoSourceSignal(), 2, SR, { bandsPerOctave: 24, minFreq: 30 });
+    meta = {
+      numBands: analysis.numBands,
+      numChannels: analysis.numChannels,
+      bandOffsets: analysis.bandOffsets,
+      bandLengths: analysis.bandLengths,
+    };
+  }, 60_000);
+
+  describe("nmf", () => {
+    it(
+      "returns the requested number of parts",
+      async () => {
+        const { parts } = await addon.nmf(analysis.data, meta, 3, 40, 1);
+        expect(parts).toHaveLength(3);
+        for (const part of parts) expect(part.length).toBe(analysis.data.length);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "splits magnitude without creating or destroying any",
+      async () => {
+        const { parts } = await addon.nmf(analysis.data, meta, 4, 60, 1);
+        let worst = 0;
+        forEachCoefficient(meta, (i) => {
+          let summed = 0;
+          for (const part of parts) summed += part[i];
+          worst = Math.max(worst, Math.abs(summed - analysis.data[i]));
+        });
+        // The masks sum to total/(total+eps), so the shortfall is the epsilon.
+        expect(worst).toBeLessThan(1e-5);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "leaves the phase channels untouched",
+      async () => {
+        const { parts } = await addon.nmf(analysis.data, meta, 3, 40, 1);
+        let changed = 0;
+        for (const part of parts) {
+          forEachCoefficient(meta, (i) => {
+            if (part[i + 1] !== analysis.data[i + 1]) changed++;
+          });
+        }
+        expect(changed).toBe(0);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "never hands a part more than the input held",
+      async () => {
+        const { parts } = await addon.nmf(analysis.data, meta, 3, 40, 1);
+        let minMagnitude = Infinity;
+        let worstExcess = 0;
+        for (const part of parts) {
+          forEachCoefficient(meta, (i) => {
+            minMagnitude = Math.min(minMagnitude, part[i]);
+            worstExcess = Math.max(worstExcess, part[i] - analysis.data[i]);
+          });
+        }
+        expect(minMagnitude).toBeGreaterThanOrEqual(0);
+        expect(worstExcess).toBeLessThan(1e-6);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "orders parts from lowest to highest spectral centroid",
+      async () => {
+        const { parts } = await addon.nmf(analysis.data, meta, 4, 80, 1);
+        const centroids = parts.map((part) => spectralCentroid(part, meta));
+        expect(centroids).toEqual([...centroids].sort((a, b) => a - b));
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "puts two well-separated sources in different parts",
+      async () => {
+        const { parts } = await addon.nmf(analysis.data, meta, 2, 150, 1);
+        const [low, high] = parts.map((part) => spectralCentroid(part, meta));
+        // 220 Hz and 3520 Hz are four octaves apart; at 24 bands per octave
+        // that is ~96 bands, so centroids close together mean the
+        // factorisation did not actually pull the two sources apart.
+        expect(high - low).toBeGreaterThan(24);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "is reproducible for a given seed and varies with it",
+      async () => {
+        const a = await addon.nmf(analysis.data, meta, 3, 40, 7);
+        const b = await addon.nmf(analysis.data, meta, 3, 40, 7);
+        const c = await addon.nmf(analysis.data, meta, 3, 40, 8);
+        expect(Array.from(a.parts[0])).toEqual(Array.from(b.parts[0]));
+        expect(Array.from(a.parts[0])).not.toEqual(Array.from(c.parts[0]));
+      },
+      TIMEOUT,
+    );
+  });
+
+  describe("mergeSpectrograms", () => {
+    it(
+      "reconstructs the input from its nmf parts",
+      async () => {
+        const { parts } = await addon.nmf(analysis.data, meta, 5, 60, 1);
+        const { merged } = await addon.mergeSpectrograms(parts, meta);
+
+        let worstMag = 0;
+        let worstPhase = 0;
+        forEachCoefficient(meta, (i) => {
+          worstMag = Math.max(worstMag, Math.abs(merged[i] - analysis.data[i]));
+          if (analysis.data[i] > 1e-4) {
+            worstPhase = Math.max(worstPhase, Math.abs(wrapToPi(merged[i + 1] - analysis.data[i + 1])));
+          }
+        });
+        expect(worstMag).toBeLessThan(1e-4);
+        expect(worstPhase).toBeLessThan(1e-3);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "keeps phase on the unwrapped branch analyze produced",
+      async () => {
+        // analyze() accumulates phase across time rather than wrapping it, and
+        // the transform effect scales that value directly. A merge that handed
+        // back atan2's [-π, π] would quietly change what a later stretch does.
+        const { parts } = await addon.nmf(analysis.data, meta, 3, 40, 1);
+        const { merged } = await addon.mergeSpectrograms(parts, meta);
+
+        let originalRange = 0;
+        let worstDrift = 0;
+        forEachCoefficient(meta, (i) => {
+          originalRange = Math.max(originalRange, Math.abs(analysis.data[i + 1]));
+          if (analysis.data[i] > 1e-4) {
+            worstDrift = Math.max(worstDrift, Math.abs(merged[i + 1] - analysis.data[i + 1]));
+          }
+        });
+        // Guards the premise: if analysis ever started wrapping, this test
+        // would pass for the wrong reason.
+        expect(originalRange).toBeGreaterThan(Math.PI);
+        expect(worstDrift).toBeLessThan(1e-3);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "reconstructs the input from its hpss parts",
+      async () => {
+        const { harmonic, percussive } = await addon.hpss(analysis.data, meta);
+        const { merged } = await addon.mergeSpectrograms([harmonic, percussive], meta);
+
+        let worstMag = 0;
+        forEachCoefficient(meta, (i) => {
+          worstMag = Math.max(worstMag, Math.abs(merged[i] - analysis.data[i]));
+        });
+        expect(worstMag).toBeLessThan(1e-4);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "adds coefficients as complex numbers, not as magnitudes",
+      async () => {
+        // Two parts holding the same magnitude in antiphase. A magnitude sum
+        // would double them; a complex sum cancels them.
+        const a = analysis.data.slice();
+        const b = analysis.data.slice();
+        forEachCoefficient(meta, (i) => {
+          a[i] *= 0.5;
+          b[i] *= 0.5;
+          b[i + 1] = a[i + 1] + Math.PI;
+        });
+
+        const { merged } = await addon.mergeSpectrograms([a, b], meta);
+        let worst = 0;
+        forEachCoefficient(meta, (i) => {
+          worst = Math.max(worst, merged[i]);
+        });
+        expect(worst).toBeLessThan(1e-5);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "is a no-op on a single input",
+      async () => {
+        const { merged } = await addon.mergeSpectrograms([analysis.data], meta);
+        let worstMag = 0;
+        let worstPhase = 0;
+        forEachCoefficient(meta, (i) => {
+          worstMag = Math.max(worstMag, Math.abs(merged[i] - analysis.data[i]));
+          worstPhase = Math.max(worstPhase, Math.abs(merged[i + 1] - analysis.data[i + 1]));
+        });
+        expect(worstMag).toBeLessThan(1e-6);
+        expect(worstPhase).toBeLessThan(1e-3);
+      },
+      TIMEOUT,
+    );
+
+    it(
+      "rejects inputs whose lengths disagree",
+      async () => {
+        await expect(
+          addon.mergeSpectrograms([analysis.data, analysis.data.slice(0, analysis.data.length - 4)], meta),
+        ).rejects.toThrow(/same length/);
+      },
+      TIMEOUT,
+    );
+  });
+});

--- a/src/main/lib/audio-analysis.ts
+++ b/src/main/lib/audio-analysis.ts
@@ -191,6 +191,44 @@ export async function hpss(
 }
 
 /**
+ * Split a spectrogram into `numComponents` parts by non-negative matrix
+ * factorisation. Like hpss this masks the magnitude channels and leaves phase
+ * alone, and the masks sum to 1, so the parts add back up to the input.
+ */
+export async function nmf(
+  packedData: Float32Array,
+  analysisMetadata: {
+    numBands: number;
+    numChannels: number;
+    bandOffsets: Uint32Array;
+    bandLengths: Uint32Array;
+  },
+  numComponents: number,
+  iterations = 120,
+  seed = 1,
+): Promise<{ parts: Float32Array[] }> {
+  const gab = init();
+  return await gab.nmf(packedData, analysisMetadata, numComponents, iterations, seed);
+}
+
+/**
+ * Sum spectrograms that share a band layout, adding the complex coefficients
+ * rather than the magnitudes so edited parts recombine coherently.
+ */
+export async function mergeSpectrograms(
+  parts: Float32Array[],
+  analysisMetadata: {
+    numBands: number;
+    numChannels: number;
+    bandOffsets: Uint32Array;
+    bandLengths: Uint32Array;
+  },
+): Promise<{ merged: Float32Array }> {
+  const gab = init();
+  return await gab.mergeSpectrograms(parts, analysisMetadata);
+}
+
+/**
  * Separate audio (already decoded to channels) into 4 stems using htdemucs ONNX.
  * Call with Gaborator-synthesized audio, then re-analyse each stem with Gaborator.
  * Stems: drums, bass, other, vocals

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -90,6 +90,27 @@ declare global {
         kernelH?: number,
         kernelV?: number,
       ) => Promise<{ harmonic: Float32Array; percussive: Float32Array }>;
+      nmf: (
+        packedData: Float32Array,
+        analysisMetadata: {
+          numBands: number;
+          numChannels: number;
+          bandOffsets: Uint32Array;
+          bandLengths: Uint32Array;
+        },
+        numComponents: number,
+        iterations?: number,
+        seed?: number,
+      ) => Promise<{ parts: Float32Array[] }>;
+      mergeSpectrograms: (
+        parts: Float32Array[],
+        analysisMetadata: {
+          numBands: number;
+          numChannels: number;
+          bandOffsets: Uint32Array;
+          bandLengths: Uint32Array;
+        },
+      ) => Promise<{ merged: Float32Array }>;
       exportAudio: (
         audioChannels: Float32Array[],
         outputPath: string,

--- a/src/renderer/src/components/file-header.tsx
+++ b/src/renderer/src/components/file-header.tsx
@@ -1,10 +1,12 @@
 import { useStore } from "@/store";
 import { ActionIcon, Badge, Box, Group, Menu, NumberInput } from "@mantine/core";
+import { openSplitPartsPrompt } from "@renderer/lib/modals";
 import { FILE_HEADER_FONT, FILE_HEADER_PAD, useUiSize } from "@renderer/lib/ui-density";
 import { getFileColor, openFiles } from "@renderer/store/files";
+import { selectStemGroupOfFile, stemMemberColor, stemMethodLabel } from "@renderer/store/stem-groups";
 import { isManagedFilePath } from "@renderer/store/utils";
 import truncateMiddle from "@stdlib/string-truncate-middle";
-import { ChevronDown, Copy, Maximize2, Minimize2, Scissors, X } from "lucide-react";
+import { ChevronDown, Combine, Copy, Maximize2, Minimize2, Scissors, X } from "lucide-react";
 import { memo } from "react";
 import { Tooltip } from "./tooltip";
 
@@ -59,9 +61,15 @@ export default memo(function FileHeader({ fileId }: { fileId: string }) {
   const bandsPerOctave = useStore((state) => state.filesBandsPerOctave[fileId]);
   const isDirty = useStore((state) => state.filesDirty[fileId] ?? false);
   const isHighlighted = useStore((state) => state.highlightedSourcePath === filePath);
+  const stemGroup = useStore((state) => selectStemGroupOfFile(state, fileId));
 
   const isFullscreen = fullscreenFileId === fileId;
-  const fileColor = getFileColor(filePath);
+  // A stem wears a shade of its group's hue instead of its own path hash, so a
+  // split reads as one unit rather than as unrelated files.
+  const stemIndex = stemGroup ? stemGroup.memberIds.indexOf(fileId) : -1;
+  const fileColor = stemGroup
+    ? stemMemberColor(stemGroup.hue, stemIndex, stemGroup.memberIds.length)
+    : getFileColor(filePath);
   // Tooltip shows full path for real files (helpful when basenames truncate);
   // for managed files the path is the opaque sentinel, so just show the label.
   const tooltipLabel = isManagedFilePath(filePath) ? displayName : filePath;
@@ -84,6 +92,19 @@ export default memo(function FileHeader({ fileId }: { fileId: string }) {
             <TruncatedFilename displayName={displayName} isDirty={isDirty} />
           </Box>
         </Tooltip>
+        {stemGroup && (
+          <Tooltip
+            label={`Part ${stemIndex + 1} of ${stemGroup.memberIds.length} from a ${stemMethodLabel(stemGroup.method)} split. These parts add back up to the file they came from.`}
+          >
+            <Badge
+              size="sm"
+              variant="light"
+              style={{ flexShrink: 0, color: fileColor, backgroundColor: `${fileColor}22` }}
+            >
+              {stemIndex + 1}/{stemGroup.memberIds.length}
+            </Badge>
+          </Tooltip>
+        )}
         {bandsPerOctave && (
           <Badge size="sm" variant="light" color="orange" style={{ flexShrink: 0 }}>
             {getResolutionLabel(bandsPerOctave)}
@@ -91,6 +112,20 @@ export default memo(function FileHeader({ fileId }: { fileId: string }) {
         )}
       </Group>
       <Group align="center" gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
+        {stemGroup && (
+          <Tooltip label="Merge every part of this split into a new file. The parts stay open.">
+            <ActionIcon
+              size={uiSize}
+              color="dark.5"
+              onClick={(e) => {
+                e.stopPropagation();
+                useStore.getState().mergeStemGroup(stemGroup.id);
+              }}
+            >
+              <Combine size={16} />
+            </ActionIcon>
+          </Tooltip>
+        )}
         <Tooltip label="The tempo of this file in beats per minute (BPM). Used for grid snapping and time-based effects.">
           <NumberInput
             w={60}
@@ -117,6 +152,19 @@ export default memo(function FileHeader({ fileId }: { fileId: string }) {
               }}
             >
               Split Harmonic and Percussive (HPSS)
+            </Menu.Item>
+            <Menu.Divider />
+            <Menu.Item
+              onClick={(e) => {
+                e.stopPropagation();
+                openSplitPartsPrompt({
+                  onConfirm: (parts) => {
+                    useStore.getState().nmfFile(fileId, parts);
+                  },
+                });
+              }}
+            >
+              Split into N Parts (NMF)…
             </Menu.Item>
             <Menu.Divider />
             <Menu.Item

--- a/src/renderer/src/components/layout/canvas-panel.tsx
+++ b/src/renderer/src/components/layout/canvas-panel.tsx
@@ -1,8 +1,15 @@
 import { useStore } from "@/store";
 import { ActionIcon, Box, Group, Loader, Stack, Text } from "@mantine/core";
 import { getFileColor, openFiles } from "@renderer/store/files";
-import { X } from "lucide-react";
-import { memo, useEffect, useRef } from "react";
+import {
+  getFileSegments,
+  selectStemGroupOfFile,
+  stemGroupColor,
+  stemMemberColor,
+  stemMethodLabel,
+} from "@renderer/store/stem-groups";
+import { Combine, Link2, Link2Off, X } from "lucide-react";
+import { memo, useEffect, useMemo, useRef, type RefObject } from "react";
 import { FileView } from "../file-view";
 import { Tooltip } from "../tooltip";
 
@@ -10,9 +17,12 @@ const PaletteChip = memo(({ fileId }: { fileId: string }) => {
   const file = openFiles[fileId];
   const isHighlighted = useStore((state) => state.highlightedSourcePath === file?.filePath);
   const isLoading = useStore((state) => !!state.filesLoading[fileId]);
+  const stemGroup = useStore((state) => selectStemGroupOfFile(state, fileId));
   if (!file) return null;
   const displayName = file.displayName;
-  const fileColor = getFileColor(file.filePath);
+  const fileColor = stemGroup
+    ? stemMemberColor(stemGroup.hue, stemGroup.memberIds.indexOf(fileId), stemGroup.memberIds.length)
+    : getFileColor(file.filePath);
 
   return (
     <Tooltip label={displayName}>
@@ -98,11 +108,120 @@ export const PaletteBar = memo(() => {
 });
 PaletteBar.displayName = "PaletteBar";
 
+type FileLaneProps = {
+  fileId: string;
+  activeFileId: string | null;
+  activeRef: RefObject<HTMLDivElement | null>;
+  fullscreenFileId: string | null;
+  minimizedFileIds: string[];
+};
+
+const FileLane = memo(({ fileId, activeFileId, activeRef, fullscreenFileId, minimizedFileIds }: FileLaneProps) => {
+  const isFullscreen = fullscreenFileId === fileId;
+  const hidden = (fullscreenFileId !== null && !isFullscreen) || minimizedFileIds.includes(fileId);
+  return (
+    <Box
+      ref={fileId === activeFileId ? activeRef : undefined}
+      style={{ display: hidden ? "none" : undefined }}
+      h={isFullscreen ? "100%" : undefined}
+      flex={isFullscreen ? 1 : undefined}
+    >
+      <FileView fileId={fileId} isFullscreen={isFullscreen} />
+    </Box>
+  );
+});
+FileLane.displayName = "FileLane";
+
+/**
+ * Wraps the lanes of one split in a rail carrying the group's colour, with a
+ * header for the operations that act on the whole group. The rail is what makes
+ * the parts read as connected rather than as files that happen to be adjacent.
+ */
+const StemGroupSection = memo(
+  ({ groupId, fileIds, ...laneProps }: { groupId: string; fileIds: string[] } & Omit<FileLaneProps, "fileId">) => {
+    const group = useStore((state) => state.stemGroups[groupId]);
+    const anyLoading = useStore((state) => fileIds.some((id) => !!state.filesLoading[id]));
+
+    // Fullscreen takes over the canvas, so the group chrome would just be a
+    // stray bar above it.
+    const chromeHidden = laneProps.fullscreenFileId !== null;
+    if (!group) {
+      return (
+        <>
+          {fileIds.map((fileId) => (
+            <FileLane key={fileId} fileId={fileId} {...laneProps} />
+          ))}
+        </>
+      );
+    }
+
+    const color = stemGroupColor(group.hue);
+
+    return (
+      <Box
+        style={{
+          borderLeft: chromeHidden ? undefined : `2px solid ${color}`,
+          paddingLeft: chromeHidden ? undefined : 6,
+          borderRadius: 2,
+        }}
+        h={laneProps.fullscreenFileId !== null ? "100%" : undefined}
+        flex={laneProps.fullscreenFileId !== null ? 1 : undefined}
+      >
+        {!chromeHidden && (
+          <Group gap="xs" wrap="nowrap" py={2} px={4} style={{ minHeight: 24 }}>
+            <Combine size={12} color={color} style={{ flexShrink: 0 }} />
+            <Text size="xs" c="dimmed" truncate="end" style={{ minWidth: 0, flex: 1 }}>
+              {group.label}
+            </Text>
+            {anyLoading && <Loader size={10} color="gray" />}
+            <Tooltip
+              label={
+                group.syncView
+                  ? "Zoom and scroll are shared across these parts. Click to unlink."
+                  : "Zoom and scroll move independently. Click to link them."
+              }
+            >
+              <ActionIcon
+                size="xs"
+                variant="subtle"
+                color={group.syncView ? "gray" : "dark.3"}
+                onClick={() => useStore.getState().setStemGroupSyncView(groupId, !group.syncView)}
+              >
+                {group.syncView ? <Link2 size={12} /> : <Link2Off size={12} />}
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip
+              label={`Merge all ${group.memberIds.length} parts of this ${stemMethodLabel(group.method)} split into a new file. The parts stay open.`}
+            >
+              <ActionIcon
+                size="xs"
+                variant="subtle"
+                color="gray"
+                loading={anyLoading}
+                onClick={() => useStore.getState().mergeStemGroup(groupId)}
+              >
+                <Combine size={12} />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
+        )}
+        <Stack gap="xs">
+          {fileIds.map((fileId) => (
+            <FileLane key={fileId} fileId={fileId} {...laneProps} />
+          ))}
+        </Stack>
+      </Box>
+    );
+  },
+);
+StemGroupSection.displayName = "StemGroupSection";
+
 export const CanvasPanel = memo(() => {
   const openFileIds = useStore((state) => state.openFileIds);
   const fullscreenFileId = useStore((state) => state.fullscreenFileId);
   const minimizedFileIds = useStore((state) => state.minimizedFileIds);
   const activeFileId = useStore((state) => state.activeFileId);
+  const stemGroupOfFile = useStore((state) => state.stemGroupOfFile);
 
   // Bring the active file into view when it changes (e.g. opening a file that's
   // already open further down the list). `nearest` keeps already-visible files put.
@@ -111,25 +230,26 @@ export const CanvasPanel = memo(() => {
     activeRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
   }, [activeFileId]);
 
+  const segments = useMemo(() => getFileSegments(openFileIds, stemGroupOfFile), [openFileIds, stemGroupOfFile]);
+  const laneProps = useMemo(
+    () => ({ activeFileId, activeRef, fullscreenFileId, minimizedFileIds }),
+    [activeFileId, fullscreenFileId, minimizedFileIds],
+  );
+
   return (
     <Stack h={fullscreenFileId ? "100%" : undefined} pos="relative" gap={"xs"}>
-      {openFileIds.map((fileId) => {
-        const isFullscreen = fullscreenFileId === fileId;
-        const isMinimized = minimizedFileIds.includes(fileId);
-        const hiddenByFullscreen = fullscreenFileId !== null && !isFullscreen;
-        const hidden = hiddenByFullscreen || isMinimized;
-        return (
-          <Box
-            key={fileId}
-            ref={fileId === activeFileId ? activeRef : undefined}
-            style={{ display: hidden ? "none" : undefined }}
-            h={isFullscreen ? "100%" : undefined}
-            flex={isFullscreen ? 1 : undefined}
-          >
-            <FileView fileId={fileId} isFullscreen={isFullscreen} />
-          </Box>
-        );
-      })}
+      {segments.map((segment, index) =>
+        segment.groupId !== null ? (
+          <StemGroupSection
+            key={`${segment.groupId}-${index}`}
+            groupId={segment.groupId}
+            fileIds={segment.fileIds}
+            {...laneProps}
+          />
+        ) : (
+          segment.fileIds.map((fileId) => <FileLane key={fileId} fileId={fileId} {...laneProps} />)
+        ),
+      )}
     </Stack>
   );
 });

--- a/src/renderer/src/lib/__tests__/stem-groups.test.ts
+++ b/src/renderer/src/lib/__tests__/stem-groups.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createStemGroupsSlice,
+  getFileSegments,
+  selectStemGroupOfFile,
+  stemGroupColor,
+  stemMemberColor,
+  stemMethodLabel,
+  type StemGroupsState,
+} from "../../store/stem-groups";
+import type { State, ZustandGet, ZustandSet } from "../../store/types";
+
+// Drives the real slice through a minimal store: the actions are written
+// against zustand's set/get and immer producers, so running them for real is
+// the only way to test the group bookkeeping without restating it here.
+function makeSlice(): { state: StemGroupsState; get: ZustandGet } {
+  let state: StemGroupsState;
+  const get = (() => state as State) as ZustandGet;
+  const set = ((partial) => {
+    const next = typeof partial === "function" ? partial(state as State) : partial;
+    state = { ...state, ...next } as StemGroupsState;
+  }) as ZustandSet;
+  state = createStemGroupsSlice(set, get);
+  return { state: new Proxy({} as StemGroupsState, { get: (_, key) => state[key as keyof StemGroupsState] }), get };
+}
+
+const GROUP = {
+  method: "nmf" as const,
+  label: "loop — 3 parts",
+  originId: "origin",
+  memberIds: ["a", "b", "c"],
+  hue: 200,
+};
+
+describe("stem groups", () => {
+  it("indexes every member back to the group", () => {
+    const { state } = makeSlice();
+    const groupId = state.createStemGroup(GROUP);
+
+    expect(state.stemGroups[groupId].memberIds).toEqual(["a", "b", "c"]);
+    expect(state.stemGroupOfFile).toEqual({ a: groupId, b: groupId, c: groupId });
+  });
+
+  it("defaults a new group to synced views", () => {
+    const { state } = makeSlice();
+    const groupId = state.createStemGroup(GROUP);
+    expect(state.stemGroups[groupId].syncView).toBe(true);
+
+    state.setStemGroupSyncView(groupId, false);
+    expect(state.stemGroups[groupId].syncView).toBe(false);
+  });
+
+  it("drops a closed file from its group", () => {
+    const { state } = makeSlice();
+    const groupId = state.createStemGroup(GROUP);
+
+    state.removeFileFromStemGroup("b");
+
+    expect(state.stemGroups[groupId].memberIds).toEqual(["a", "c"]);
+    expect(state.stemGroupOfFile).toEqual({ a: groupId, c: groupId });
+  });
+
+  it("discards a group once fewer than two members remain", () => {
+    const { state } = makeSlice();
+    const groupId = state.createStemGroup(GROUP);
+
+    state.removeFileFromStemGroup("b");
+    state.removeFileFromStemGroup("c");
+
+    expect(state.stemGroups[groupId]).toBeUndefined();
+    expect(state.stemGroupOfFile).toEqual({});
+  });
+
+  it("ignores files that belong to no group", () => {
+    const { state } = makeSlice();
+    const groupId = state.createStemGroup(GROUP);
+
+    state.removeFileFromStemGroup("unrelated");
+
+    expect(state.stemGroups[groupId].memberIds).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps groups independent of each other", () => {
+    const { state } = makeSlice();
+    const first = state.createStemGroup(GROUP);
+    const second = state.createStemGroup({ ...GROUP, memberIds: ["d", "e"], originId: "other" });
+
+    state.removeFileFromStemGroup("d");
+
+    expect(state.stemGroups[second]).toBeUndefined();
+    expect(state.stemGroups[first].memberIds).toEqual(["a", "b", "c"]);
+    expect(state.stemGroupOfFile).toEqual({ a: first, b: first, c: first });
+  });
+
+  it("looks a group up from any of its members", () => {
+    const { state, get } = makeSlice();
+    const groupId = state.createStemGroup(GROUP);
+
+    expect(selectStemGroupOfFile(get(), "b")?.id).toBe(groupId);
+    expect(selectStemGroupOfFile(get(), "origin")).toBeUndefined();
+  });
+});
+
+describe("getFileSegments", () => {
+  it("brackets a run of group members and leaves loose files alone", () => {
+    const segments = getFileSegments(["source", "a", "b", "other"], { a: "g1", b: "g1" });
+
+    expect(segments).toEqual([
+      { groupId: null, fileIds: ["source"] },
+      { groupId: "g1", fileIds: ["a", "b"] },
+      { groupId: null, fileIds: ["other"] },
+    ]);
+  });
+
+  it("keeps adjacent groups apart", () => {
+    const segments = getFileSegments(["a", "b", "c", "d"], { a: "g1", b: "g1", c: "g2", d: "g2" });
+
+    expect(segments).toEqual([
+      { groupId: "g1", fileIds: ["a", "b"] },
+      { groupId: "g2", fileIds: ["c", "d"] },
+    ]);
+  });
+
+  it("brackets each run separately when a group is split up", () => {
+    const segments = getFileSegments(["a", "loose", "b"], { a: "g1", b: "g1" });
+
+    expect(segments).toEqual([
+      { groupId: "g1", fileIds: ["a"] },
+      { groupId: null, fileIds: ["loose"] },
+      { groupId: "g1", fileIds: ["b"] },
+    ]);
+  });
+
+  it("returns nothing for no open files", () => {
+    expect(getFileSegments([], {})).toEqual([]);
+  });
+});
+
+describe("stem colours", () => {
+  it("gives every member the group's hue at a distinct lightness", () => {
+    const colors = [0, 1, 2, 3].map((i) => stemMemberColor(210, i, 4));
+
+    for (const color of colors) expect(color).toContain("hsl(210,");
+    expect(new Set(colors).size).toBe(4);
+  });
+
+  it("centres a lone member rather than putting it at an extreme", () => {
+    const solo = stemMemberColor(210, 0, 1);
+    expect(solo).toBe(stemGroupColor(210));
+  });
+
+  it("names each method", () => {
+    expect(stemMethodLabel("hpss")).toBe("HPSS");
+    expect(stemMethodLabel("nmf")).toBe("NMF");
+    expect(stemMethodLabel("ai")).toBe("AI stems");
+  });
+});

--- a/src/renderer/src/lib/host/extension-analysis.ts
+++ b/src/renderer/src/lib/host/extension-analysis.ts
@@ -120,6 +120,8 @@ export function createExtensionAnalysis(): AnalysisApi {
     downloadModel: () => notImplemented("downloadModel"),
     aiSeparate: () => notImplemented("aiSeparate"),
     hpss: () => notImplemented("hpss"),
+    nmf: () => notImplemented("nmf"),
+    mergeSpectrograms: () => notImplemented("mergeSpectrograms"),
     exportAudio: () => notImplemented("exportAudio"),
     decodeAudio: () => notImplemented("decodeAudio"),
     copyAudioFile: () => notImplemented("copyAudioFile"),

--- a/src/renderer/src/lib/modals.tsx
+++ b/src/renderer/src/lib/modals.tsx
@@ -251,6 +251,54 @@ const ReanalyzeBody = ({ initial, onChange }: { initial: number; onChange: (v: n
   );
 };
 
+type OpenSplitPartsPromptOptions = {
+  defaultParts?: number;
+  onConfirm: (parts: number) => void | Promise<void>;
+  onCancel?: () => void;
+  onClose?: () => void;
+};
+
+export function openSplitPartsPrompt({
+  defaultParts = 4,
+  onConfirm,
+  onCancel,
+  onClose,
+}: OpenSplitPartsPromptOptions): string {
+  const partsRef: RefObject<HTMLInputElement | null> = { current: null };
+
+  return openConfirmModal({
+    title: "Split into parts",
+    children: (
+      <Stack gap="xs">
+        <Text size="sm" c="dimmed">
+          Factorises the spectrogram into layers that each capture a recurring sound, ordered from lowest to highest.
+          The parts stay linked and add back up to this file.
+        </Text>
+        <NumberInput
+          ref={partsRef}
+          size="xs"
+          label="Parts"
+          defaultValue={defaultParts}
+          min={2}
+          max={16}
+          step={1}
+          data-autofocus
+        />
+      </Stack>
+    ),
+    labels: { confirm: "Split", cancel: "Cancel" },
+    confirmProps: { size: "xs" },
+    cancelProps: { size: "xs" },
+    onConfirm: async () => {
+      const parts = parseInt(partsRef.current?.value ?? "");
+      if (!Number.isFinite(parts)) return;
+      await onConfirm(Math.min(16, Math.max(2, parts)));
+    },
+    onCancel,
+    onClose,
+  });
+}
+
 export function openReanalyzePrompt({
   initialBandsPerOctave,
   onConfirm,

--- a/src/renderer/src/store/files.ts
+++ b/src/renderer/src/store/files.ts
@@ -11,7 +11,8 @@ import { isBundledPath, resolveBundledPath } from "../lib/bundled-samples";
 import type { HostRender } from "../lib/host/types";
 import { destroyHistoryManager, getHistoryManager } from "../lib/history-manager";
 import { buildChildIndexPaths, chainFromRootTo, runHistoryExport } from "../lib/history-export";
-import type { Brush, OpenFile, ParameterKey, State, ZustandGet, ZustandSet } from "./types";
+import type { Brush, OpenFile, ParameterKey, SpectrogramData, State, ZustandGet, ZustandSet } from "./types";
+import type { StemGroupMethod } from "./stem-groups";
 import { generateFileId, isManagedFilePath, makeManagedFilePath } from "./utils";
 
 export interface FilesState {
@@ -21,6 +22,10 @@ export interface FilesState {
   duplicateFile: (fileId: string) => Promise<void>;
   hpssFile: (fileId: string) => Promise<void>;
   aiSeparateFile: (fileId: string) => Promise<void>;
+  nmfFile: (fileId: string, numComponents: number) => Promise<void>;
+  /** Sum the given files into a new one, leaving the originals open. */
+  mergeStems: (fileIds: string[]) => Promise<void>;
+  mergeStemGroup: (groupId: string) => Promise<void>;
   saveActiveFile: () => Promise<void>;
   saveActiveFileAs: () => Promise<void>;
   saveActiveFileVersion: () => Promise<void>;
@@ -233,14 +238,18 @@ async function loadRealFileViaGaborator(
 // In-flight AI separation guard — blocks a second concurrent stem split on the same file.
 const aiSeparatingFileIds = new Set<string>();
 
+/** Stable 0-359 hue for a string, so the same path always reads the same colour. */
+export function hashHue(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = value.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return ((hash % 360) + 360) % 360;
+}
+
 /** Get a consistent colour for a file based on a hash of its file path. */
 export function getFileColor(filePath: string): string {
-  let hash = 0;
-  for (let i = 0; i < filePath.length; i++) {
-    hash = filePath.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  const hue = ((hash % 360) + 360) % 360;
-  return `hsl(${hue}, 60%, 60%)`;
+  return `hsl(${hashHue(filePath)}, 60%, 60%)`;
 }
 
 /** Look up an open file by its file path. Returns the first match or undefined. */
@@ -319,6 +328,149 @@ export function getFileById(fileId: string): OpenFile | undefined {
 // Helper to find file ID by path
 export function getFileIdByPath(filePath: string): string | undefined {
   return Object.keys(openFiles).find((id) => openFiles[id].filePath === filePath);
+}
+
+// ─── Stem splitting ──────────────────────────────────────────────────────────
+
+// Derive a child spectrogram from the file it was split from: same grid, same
+// metadata, new coefficients. The typed arrays are copied so editing the child
+// never writes through to its source.
+function deriveSpectrogramData(base: SpectrogramData, packedData: Float32Array): SpectrogramData {
+  return {
+    ...base,
+    packedData,
+    inverseMap: base.inverseMap.slice(),
+    metadata: base.metadata.slice(),
+    synthesisMetadata: {
+      bandLengths: base.synthesisMetadata.bandLengths.slice(),
+      bandOffsets: base.synthesisMetadata.bandOffsets.slice(),
+      bandStepLog2s: base.synthesisMetadata.bandStepLog2s.slice(),
+    },
+  };
+}
+
+// The metadata shape the coefficient-domain addon entry points (hpss, nmf,
+// mergeSpectrograms) expect.
+function bandLayout(data: SpectrogramData) {
+  return {
+    numBands: data.numBands,
+    numChannels: data.numChannels,
+    bandOffsets: data.synthesisMetadata.bandOffsets,
+    bandLengths: data.synthesisMetadata.bandLengths,
+  };
+}
+
+// The current painted state of a file, falling back to its analysed
+// coefficients when no renderer is mounted to read an FBO from.
+async function readCurrentPackedData(file: OpenFile): Promise<Float32Array | undefined> {
+  const fboData = await file.rendererRef?.current?.getFBOData();
+  return fboData ?? file.spectrogramData?.packedData;
+}
+
+// Insert placeholder files for a pending split directly after their source so
+// they appear with a spinner while the separator runs. The caller fills in each
+// file's spectrogramData when it returns, or calls discardFiles on failure.
+function createStemPlaceholders(
+  set: ZustandSet,
+  get: ZustandGet,
+  sourceFileId: string,
+  labels: string[],
+  loadingMessage: string,
+): string[] {
+  const sourceFile = openFiles[sourceFileId];
+  const baseLabel = stripExtensionForLabel(sourceFile.displayName);
+  const ids = labels.map(() => generateFileId());
+  const sourceBpm = get().filepathsBpm[sourceFile.filePath];
+
+  for (let i = 0; i < ids.length; i++) {
+    openFiles[ids[i]] = {
+      id: ids[i],
+      filePath: makeManagedFilePath(ids[i]),
+      displayName: `${baseLabel} ${labels[i]}`,
+    };
+  }
+
+  set(
+    produce((state: State) => {
+      const idx = state.openFileIds.indexOf(sourceFileId);
+      state.openFileIds.splice(idx + 1, 0, ...ids);
+      for (const id of ids) {
+        state.filesBandsPerOctave[id] = state.filesBandsPerOctave[sourceFileId];
+        state.filesZoom[id] = state.filesZoom[sourceFileId];
+        state.filesOffset[id] = state.filesOffset[sourceFileId];
+        state.filesZoomY[id] = state.filesZoomY[sourceFileId] ?? 0;
+        state.filesOffsetY[id] = state.filesOffsetY[sourceFileId] ?? 0;
+        state.filesPlaybackStartTime[id] = 0;
+        state.filesDirty[id] = true;
+        state.persistedFilePaths[id] = openFiles[id].filePath;
+        state.fileDisplayNames[id] = openFiles[id].displayName;
+        if (sourceBpm !== undefined) state.filepathsBpm[openFiles[id].filePath] = sourceBpm;
+        state.filesLoading[id] = loadingMessage;
+      }
+    }),
+  );
+
+  return ids;
+}
+
+// Remove files created for an operation that then failed, along with every
+// per-file map entry seeded for them.
+function discardFiles(set: ZustandSet, ids: string[]): void {
+  for (const id of ids) delete openFiles[id];
+  set(
+    produce((state: State) => {
+      state.openFileIds = state.openFileIds.filter((id) => !ids.includes(id));
+      for (const id of ids) {
+        delete state.filesBandsPerOctave[id];
+        delete state.filesZoom[id];
+        delete state.filesOffset[id];
+        delete state.filesZoomY[id];
+        delete state.filesOffsetY[id];
+        delete state.filesPlaybackStartTime[id];
+        delete state.filesDirty[id];
+        delete state.filesLoading[id];
+        delete state.persistedFilePaths[id];
+        delete state.fileDisplayNames[id];
+      }
+    }),
+  );
+}
+
+function clearLoading(set: ZustandSet, ids: string[]): void {
+  set(
+    produce((state: State) => {
+      for (const id of ids) delete state.filesLoading[id];
+    }),
+  );
+}
+
+// Register a completed split so its parts stay visibly connected and can be
+// summed back together. The hue comes from the source path, so a group reads as
+// a shade of the file it came from.
+function registerStemGroup(
+  get: ZustandGet,
+  method: StemGroupMethod,
+  sourceFileId: string,
+  memberIds: string[],
+  label: string,
+): void {
+  const sourceFile = openFiles[sourceFileId];
+  get().createStemGroup({
+    method,
+    label,
+    originId: sourceFileId,
+    memberIds,
+    hue: hashHue(sourceFile?.filePath ?? sourceFileId),
+  });
+}
+
+// Files whose view a change to `fileId` should also move: itself, plus the rest
+// of its stem group while that group has view sync switched on.
+function viewSyncTargets(state: State, fileId: string): string[] {
+  const groupId = state.stemGroupOfFile[fileId];
+  const group = groupId ? state.stemGroups[groupId] : undefined;
+  if (!group?.syncView) return [fileId];
+  return group.memberIds.includes(fileId) ? group.memberIds : [fileId, ...group.memberIds];
 }
 
 export const FILES_PERSISTED_KEYS = [
@@ -580,75 +732,176 @@ export const createFilesSlice = (set: ZustandSet, get: ZustandGet): FilesState =
     const { spectrogramData } = originalFile;
     if (!spectrogramData) return;
 
-    const harmonicId = generateFileId();
-    const percussiveId = generateFileId();
-
     const baseLabel = stripExtensionForLabel(originalFile.displayName);
-    // Add placeholder files immediately so they appear in the UI with a loading state
-    openFiles[harmonicId] = {
-      id: harmonicId,
-      filePath: makeManagedFilePath(harmonicId),
-      displayName: `${baseLabel} harmonic`,
-    };
-    openFiles[percussiveId] = {
-      id: percussiveId,
-      filePath: makeManagedFilePath(percussiveId),
-      displayName: `${baseLabel} percussive`,
-    };
+    const ids = createStemPlaceholders(
+      set,
+      get,
+      fileId,
+      ["harmonic", "percussive"],
+      "Separating harmonic and percussive...",
+    );
 
-    const sourceBpm = get().filepathsBpm[originalFile.filePath];
+    try {
+      const { harmonic, percussive } = await host.analysis.hpss(fboData, bandLayout(spectrogramData));
+
+      openFiles[ids[0]] = { ...openFiles[ids[0]], spectrogramData: deriveSpectrogramData(spectrogramData, harmonic) };
+      openFiles[ids[1]] = { ...openFiles[ids[1]], spectrogramData: deriveSpectrogramData(spectrogramData, percussive) };
+    } catch (error) {
+      console.error("HPSS separation failed:", error);
+      notifications.show({
+        title: "Separation failed",
+        message: `${error instanceof Error ? error.message : "Unknown error"}`,
+        color: "red",
+      });
+      discardFiles(set, ids);
+      return;
+    }
+
+    clearLoading(set, ids);
+    registerStemGroup(get, "hpss", fileId, ids, `${baseLabel} — harmonic / percussive`);
+  },
+  nmfFile: async (fileId: string, numComponents: number) => {
+    const originalFile = openFiles[fileId];
+    if (!originalFile) return;
+
+    const fboData = await originalFile.rendererRef?.current?.getFBOData();
+    if (!fboData) return;
+
+    const { spectrogramData } = originalFile;
+    if (!spectrogramData) return;
+
+    const parts = Math.max(2, Math.round(numComponents));
+    const baseLabel = stripExtensionForLabel(originalFile.displayName);
+    const labels = Array.from({ length: parts }, (_, i) => `part ${i + 1}`);
+    const ids = createStemPlaceholders(set, get, fileId, labels, `Splitting into ${parts} parts...`);
+
+    try {
+      const result = await host.analysis.nmf(fboData, bandLayout(spectrogramData), parts);
+      if (result.parts.length !== parts) {
+        throw new Error(`Expected ${parts} parts, got ${result.parts.length}`);
+      }
+      for (let i = 0; i < ids.length; i++) {
+        openFiles[ids[i]] = {
+          ...openFiles[ids[i]],
+          spectrogramData: deriveSpectrogramData(spectrogramData, result.parts[i]),
+        };
+      }
+    } catch (error) {
+      console.error("NMF separation failed:", error);
+      notifications.show({
+        title: "Separation failed",
+        message: `${error instanceof Error ? error.message : "Unknown error"}`,
+        color: "red",
+      });
+      discardFiles(set, ids);
+      return;
+    }
+
+    clearLoading(set, ids);
+    registerStemGroup(get, "nmf", fileId, ids, `${baseLabel} — ${parts} parts`);
+  },
+  mergeStems: async (fileIds: string[]) => {
+    if (fileIds.length < 2) return;
+    const files = fileIds.map((id) => openFiles[id]);
+    // Merging a subset of what was asked for would quietly drop energy, so a
+    // part that hasn't finished loading blocks the whole thing.
+    if (files.some((f) => !f?.spectrogramData)) {
+      notifications.show({
+        title: "Can't merge yet",
+        message: "One of these files is still loading.",
+        color: "yellow",
+      });
+      return;
+    }
+
+    const base = files[0].spectrogramData as SpectrogramData;
+    // Summing only means anything while every part still describes the same
+    // grid; a length- or resolution-changing edit on one of them breaks that.
+    const mismatched = files.find((f) => {
+      const data = f.spectrogramData as SpectrogramData;
+      return (
+        data.numBands !== base.numBands ||
+        data.numChannels !== base.numChannels ||
+        data.numFrames !== base.numFrames ||
+        data.sampleRate !== base.sampleRate ||
+        data.bandsPerOctave !== base.bandsPerOctave
+      );
+    });
+    if (mismatched) {
+      notifications.show({
+        title: "Can't merge these files",
+        message: `'${truncateMiddle(mismatched.displayName, 40)}' no longer lines up with the others — its length or resolution has changed.`,
+        color: "red",
+      });
+      return;
+    }
+
+    const groupId = get().stemGroupOfFile[fileIds[0]];
+    const group = groupId ? get().stemGroups[groupId] : undefined;
+    const originFile = group ? openFiles[group.originId] : undefined;
+    const displayName = `${stripExtensionForLabel(originFile?.displayName ?? files[0].displayName)} merged`;
+
+    const newFileId = generateFileId();
+    const newFilePath = makeManagedFilePath(newFileId);
+    openFiles[newFileId] = { id: newFileId, filePath: newFilePath, displayName };
+
+    const sourceId = files[0].id;
+    const sourceBpm = get().filepathsBpm[files[0].filePath];
 
     set(
       produce((state: State) => {
-        const idx = state.openFileIds.indexOf(fileId);
-        state.openFileIds.splice(idx + 1, 0, harmonicId, percussiveId);
-        for (const id of [harmonicId, percussiveId]) {
-          const newPath = openFiles[id].filePath;
-          state.filesBandsPerOctave[id] = state.filesBandsPerOctave[fileId];
-          state.filesZoom[id] = state.filesZoom[fileId];
-          state.filesOffset[id] = state.filesOffset[fileId];
-          state.filesZoomY[id] = state.filesZoomY[fileId] ?? 0;
-          state.filesOffsetY[id] = state.filesOffsetY[fileId] ?? 0;
-          state.filesPlaybackStartTime[id] = 0;
-          state.filesDirty[id] = true;
-          state.persistedFilePaths[id] = newPath;
-          state.fileDisplayNames[id] = openFiles[id].displayName;
-          state.filepathsBpm[newPath] = sourceBpm;
-          state.filesLoading[id] = "Separating harmonic and percussive...";
-        }
+        const lastIdx = fileIds.reduce((max, id) => Math.max(max, state.openFileIds.indexOf(id)), -1);
+        state.openFileIds.splice(lastIdx + 1, 0, newFileId);
+        state.filesBandsPerOctave[newFileId] = state.filesBandsPerOctave[sourceId];
+        state.filesZoom[newFileId] = state.filesZoom[sourceId];
+        state.filesOffset[newFileId] = state.filesOffset[sourceId];
+        state.filesZoomY[newFileId] = state.filesZoomY[sourceId] ?? 0;
+        state.filesOffsetY[newFileId] = state.filesOffsetY[sourceId] ?? 0;
+        state.filesPlaybackStartTime[newFileId] = 0;
+        state.filesDirty[newFileId] = true;
+        state.persistedFilePaths[newFileId] = newFilePath;
+        state.fileDisplayNames[newFileId] = displayName;
+        if (sourceBpm !== undefined) state.filepathsBpm[newFilePath] = sourceBpm;
+        state.filesLoading[newFileId] = "Merging...";
       }),
     );
 
     try {
-      const { harmonic, percussive } = await host.analysis.hpss(fboData, {
-        numBands: spectrogramData.numBands,
-        numChannels: spectrogramData.numChannels,
-        bandOffsets: spectrogramData.synthesisMetadata.bandOffsets,
-        bandLengths: spectrogramData.synthesisMetadata.bandLengths,
-      });
+      const packed = await Promise.all(files.map((f) => readCurrentPackedData(f)));
+      const parts = packed.filter((p): p is Float32Array => Boolean(p));
+      if (parts.length !== files.length) throw new Error("Could not read the current state of every file");
 
-      const makeSpectrogramData = (data: Float32Array) => ({
-        ...spectrogramData,
-        packedData: data,
-        inverseMap: spectrogramData.inverseMap.slice(),
-        metadata: spectrogramData.metadata.slice(),
-        synthesisMetadata: {
-          bandLengths: spectrogramData.synthesisMetadata.bandLengths.slice(),
-          bandOffsets: spectrogramData.synthesisMetadata.bandOffsets.slice(),
-          bandStepLog2s: spectrogramData.synthesisMetadata.bandStepLog2s.slice(),
+      const { merged } = await host.analysis.mergeSpectrograms(parts, bandLayout(base));
+
+      openFiles[newFileId] = {
+        ...openFiles[newFileId],
+        spectrogramData: {
+          ...deriveSpectrogramData(base, merged),
+          // The parts each carry a slice of the original's energy, so none of
+          // their totals describes the sum. Take the figure the split came
+          // from when it's still around; the Convolve effect normalises its
+          // impulse response against it.
+          magnitudeEnergy: originFile?.spectrogramData?.magnitudeEnergy ?? base.magnitudeEnergy,
         },
+      };
+    } catch (error) {
+      console.error("Merge failed:", error);
+      notifications.show({
+        title: "Merge failed",
+        message: `${error instanceof Error ? error.message : "Unknown error"}`,
+        color: "red",
       });
-
-      openFiles[harmonicId] = { ...openFiles[harmonicId], spectrogramData: makeSpectrogramData(harmonic) };
-      openFiles[percussiveId] = { ...openFiles[percussiveId], spectrogramData: makeSpectrogramData(percussive) };
-    } finally {
-      set(
-        produce((state: State) => {
-          delete state.filesLoading[harmonicId];
-          delete state.filesLoading[percussiveId];
-        }),
-      );
+      discardFiles(set, [newFileId]);
+      return;
     }
+
+    clearLoading(set, [newFileId]);
+    await get().setActiveFileId(newFileId);
+  },
+  mergeStemGroup: async (groupId: string) => {
+    const group = get().stemGroups[groupId];
+    if (!group) return;
+    await get().mergeStems(group.memberIds);
   },
   aiSeparateFile: async (fileId: string) => {
     const originalFile = openFiles[fileId];
@@ -709,41 +962,9 @@ export const createFilesSlice = (set: ZustandSet, get: ZustandGet): FilesState =
       }
     }
 
-    const state = get();
     const stemNames = ["drums", "bass", "other", "vocals"];
-    const stemIds = stemNames.map(() => generateFileId());
-
-    const sourceBpm = state.filepathsBpm[originalFile.filePath];
-
     const baseLabel = stripExtensionForLabel(originalFile.displayName);
-    for (let i = 0; i < stemNames.length; i++) {
-      openFiles[stemIds[i]] = {
-        id: stemIds[i],
-        filePath: makeManagedFilePath(stemIds[i]),
-        displayName: `${baseLabel} ${stemNames[i]}`,
-      };
-    }
-
-    set(
-      produce((state: State) => {
-        const idx = state.openFileIds.indexOf(fileId);
-        state.openFileIds.splice(idx + 1, 0, ...stemIds);
-        for (let i = 0; i < stemIds.length; i++) {
-          const id = stemIds[i];
-          state.filesBandsPerOctave[id] = state.filesBandsPerOctave[fileId];
-          state.filesZoom[id] = state.filesZoom[fileId];
-          state.filesOffset[id] = state.filesOffset[fileId];
-          state.filesZoomY[id] = state.filesZoomY[fileId] ?? 0;
-          state.filesOffsetY[id] = state.filesOffsetY[fileId] ?? 0;
-          state.filesPlaybackStartTime[id] = 0;
-          state.filesDirty[id] = true;
-          state.persistedFilePaths[id] = openFiles[id].filePath;
-          state.fileDisplayNames[id] = openFiles[id].displayName;
-          state.filepathsBpm[openFiles[id].filePath] = sourceBpm;
-          state.filesLoading[id] = "Separating stems (AI)…";
-        }
-      }),
-    );
+    const stemIds = createStemPlaceholders(set, get, fileId, stemNames, "Separating stems (AI)…");
 
     let audioContext: AudioContext | null = null;
     try {
@@ -806,8 +1027,11 @@ export const createFilesSlice = (set: ZustandSet, get: ZustandGet): FilesState =
             numChannels: result.numChannels,
             sampleRate: result.sampleRate,
             packedTextureSize: new Vector2(result.textureWidth, result.textureHeight),
-            minFreq: state.minFreq,
-            bandsPerOctave: state.bandsPerOctave,
+            // From analysisParams, not the current global setting — a stem has
+            // to record the resolution it was actually analysed at, or it stops
+            // lining up with the file it was split from.
+            minFreq: analysisParams.minFreq,
+            bandsPerOctave: analysisParams.bandsPerOctave,
             magnitudeEnergy: result.magnitudeEnergy,
             synthesisMetadata: {
               bandOffsets: result.bandOffsets,
@@ -828,34 +1052,13 @@ export const createFilesSlice = (set: ZustandSet, get: ZustandGet): FilesState =
         message: `${error instanceof Error ? error.message : "Unknown error"}`,
         color: "red",
       });
-      const idsToRemove = [...stemIds];
-      for (const id of idsToRemove) delete openFiles[id];
-      set(
-        produce((state: State) => {
-          state.openFileIds = state.openFileIds.filter((id) => !idsToRemove.includes(id));
-          for (const id of idsToRemove) {
-            delete state.filesBandsPerOctave[id];
-            delete state.filesZoom[id];
-            delete state.filesOffset[id];
-            delete state.filesZoomY[id];
-            delete state.filesOffsetY[id];
-            delete state.filesPlaybackStartTime[id];
-            delete state.filesDirty[id];
-            delete state.filesLoading[id];
-            delete state.persistedFilePaths[id];
-            delete state.fileDisplayNames[id];
-          }
-        }),
-      );
+      discardFiles(set, stemIds);
       aiSeparatingFileIds.delete(fileId);
       return;
     }
 
-    set(
-      produce((state: State) => {
-        for (const id of stemIds) delete state.filesLoading[id];
-      }),
-    );
+    clearLoading(set, stemIds);
+    registerStemGroup(get, "ai", fileId, stemIds, `${baseLabel} — drums / bass / other / vocals`);
     aiSeparatingFileIds.delete(fileId);
   },
   saveActiveFile: async () => {
@@ -1158,6 +1361,8 @@ export const createFilesSlice = (set: ZustandSet, get: ZustandGet): FilesState =
 
     // Fire-and-forget: drops on-disk history directory and in-memory state.
     destroyHistoryManager(fileId).catch((err: unknown) => console.error("destroyHistoryManager failed", err));
+
+    state.removeFileFromStemGroup(fileId);
 
     return set(
       produce((state: State) => {
@@ -1807,28 +2012,28 @@ export const createFilesSlice = (set: ZustandSet, get: ZustandGet): FilesState =
   setFileZoom: (fileId: string, zoom: number) =>
     set(
       produce((state: State) => {
-        state.filesZoom[fileId] = zoom;
+        for (const id of viewSyncTargets(state, fileId)) state.filesZoom[id] = zoom;
       }),
     ),
   filesOffset: {},
   setFileOffset: (fileId: string, offset: number) =>
     set(
       produce((state: State) => {
-        state.filesOffset[fileId] = offset;
+        for (const id of viewSyncTargets(state, fileId)) state.filesOffset[id] = offset;
       }),
     ),
   filesZoomY: {},
   setFileZoomY: (fileId: string, zoom: number) =>
     set(
       produce((state: State) => {
-        state.filesZoomY[fileId] = zoom;
+        for (const id of viewSyncTargets(state, fileId)) state.filesZoomY[id] = zoom;
       }),
     ),
   filesOffsetY: {},
   setFileOffsetY: (fileId: string, offset: number) =>
     set(
       produce((state: State) => {
-        state.filesOffsetY[fileId] = offset;
+        for (const id of viewSyncTargets(state, fileId)) state.filesOffsetY[id] = offset;
       }),
     ),
   persistedFilePaths: {},

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -15,6 +15,7 @@ import { createFilesSlice, FILES_PERSISTED_KEYS, openFiles } from "./files";
 import { createLinkSlice, LINK_PERSISTED_KEYS } from "./link";
 import { createModulatorsSlice } from "./modulators";
 import { createPresetsSlice, PRESETS_PERSISTED_KEYS } from "./presets";
+import { createStemGroupsSlice, STEM_GROUPS_PERSISTED_KEYS } from "./stem-groups";
 import { createStepsSlice, STEPS_PERSISTED_KEYS } from "./steps";
 import type { ParameterKey, State } from "./types";
 import { isManagedFilePath } from "./utils";
@@ -36,6 +37,7 @@ export const ALL_PERSISTED_KEYS: (keyof State)[] = [
   ...PRESETS_PERSISTED_KEYS,
   ...STEPS_PERSISTED_KEYS,
   ...LINK_PERSISTED_KEYS,
+  ...STEM_GROUPS_PERSISTED_KEYS,
   ...APP_PERSISTED_KEYS,
   "randomizationAmounts",
   "excludedFromRandomization",
@@ -111,9 +113,10 @@ function persistProjection(state: State): Record<string, unknown> {
     {} as Record<string, any>,
   );
 
-  // Only persist file entries backed by a real on-disk path. Virtual files
-  // (new/duplicate/stems) appear in openFileIds at runtime but must not round-trip
-  // across sessions — they have no reanalysable source.
+  // Only persist file entries that have somewhere to be rehydrated from. That
+  // covers real on-disk paths and the `managed://` sentinels of virtual files
+  // (new/duplicate/stems), which reopenPersistedFiles restores from their
+  // history dir; anything else is dropped.
   const realIds = new Set(Object.keys(state.persistedFilePaths ?? {}));
   if (Array.isArray(picked.openFileIds)) {
     picked.openFileIds = picked.openFileIds.filter((id: string) => realIds.has(id));
@@ -142,6 +145,23 @@ function persistProjection(state: State): Record<string, unknown> {
       picked[mapKey] = Object.fromEntries(Object.entries(map).filter(([id]) => realIds.has(id)));
     }
   }
+
+  // Stem groups follow their members: drop any member that isn't coming back,
+  // and drop the group itself once fewer than two members remain.
+  const groups = picked.stemGroups as Record<string, { memberIds: string[] }> | undefined;
+  if (groups && typeof groups === "object") {
+    const keptGroups: Record<string, unknown> = {};
+    const keptOfFile: Record<string, string> = {};
+    for (const [groupId, group] of Object.entries(groups)) {
+      const memberIds = (group.memberIds ?? []).filter((id) => realIds.has(id));
+      if (memberIds.length < 2) continue;
+      keptGroups[groupId] = { ...group, memberIds };
+      for (const id of memberIds) keptOfFile[id] = groupId;
+    }
+    picked.stemGroups = keptGroups;
+    picked.stemGroupOfFile = keptOfFile;
+  }
+
   return picked;
 }
 
@@ -158,6 +178,7 @@ export const useStore = create<State>()(
         ...createPresetsSlice(set, get),
         ...createStepsSlice(set, get),
         ...createLinkSlice(set, get),
+        ...createStemGroupsSlice(set, get),
         setParameter: (key: ParameterKey, value: unknown, effectId?: string) => {
           const state = get();
           const activeBrush = state.brushes[state.activeBrushIndex];

--- a/src/renderer/src/store/stem-groups.ts
+++ b/src/renderer/src/store/stem-groups.ts
@@ -1,0 +1,156 @@
+import { produce } from "immer";
+import type { State, ZustandGet, ZustandSet } from "./types";
+
+/** Which separator produced a group's members. */
+export type StemGroupMethod = "hpss" | "ai" | "nmf";
+
+/**
+ * A set of files produced by one split of a single source file. The members are
+ * ordinary files — every brush and effect works on them unchanged — but they are
+ * tracked together because their coefficients still sum back to what they were
+ * split from, which is what makes merging them meaningful.
+ */
+export type StemGroup = {
+  id: string;
+  method: StemGroupMethod;
+  /** Shown on the group header, e.g. "loop — 6 parts". */
+  label: string;
+  /** The file the split came from. May have been closed since. */
+  originId: string;
+  /** In split order: low-to-high spectral centroid for NMF, model order for AI. */
+  memberIds: string[];
+  /** Hue shared by every member so the group reads as one unit. */
+  hue: number;
+  /** Whether zoom and scroll follow each other across members. */
+  syncView: boolean;
+};
+
+export const STEM_GROUPS_PERSISTED_KEYS = ["stemGroups", "stemGroupOfFile"] as const;
+
+export interface StemGroupsState {
+  stemGroups: Record<string, StemGroup>;
+  /** Reverse index: fileId → groupId, for the per-file lookups the UI does. */
+  stemGroupOfFile: Record<string, string>;
+  createStemGroup: (group: Omit<StemGroup, "id" | "syncView"> & { syncView?: boolean }) => string;
+  setStemGroupSyncView: (groupId: string, syncView: boolean) => void;
+  /**
+   * Drop a file from whatever group it belongs to. A group that falls below two
+   * members stops being a group and is discarded — the remaining file keeps its
+   * contents, it just loses the bracket.
+   */
+  removeFileFromStemGroup: (fileId: string) => void;
+}
+
+let stemGroupCounter = 0;
+
+function nextStemGroupId(): string {
+  stemGroupCounter++;
+  return `stemgroup_${Date.now()}_${stemGroupCounter}`;
+}
+
+/**
+ * Per-member colour: one hue for the group, stepped in lightness so members are
+ * still told apart at a glance. A lone member sits in the middle of the range.
+ */
+export function stemMemberColor(hue: number, index: number, count: number): string {
+  const lightness = count > 1 ? 42 + (30 * Math.max(0, index)) / (count - 1) : 57;
+  return `hsl(${hue}, 62%, ${lightness}%)`;
+}
+
+/** Colour for group-level chrome (the bracket rail, the group header border). */
+export function stemGroupColor(hue: number): string {
+  return `hsl(${hue}, 62%, 57%)`;
+}
+
+/**
+ * The group a file belongs to, or undefined. Returns the stored group object so
+ * it stays reference-stable across unrelated store updates.
+ */
+export function selectStemGroupOfFile(state: State, fileId: string): StemGroup | undefined {
+  const groupId = state.stemGroupOfFile[fileId];
+  return groupId ? state.stemGroups[groupId] : undefined;
+}
+
+/** How a group's method reads in the UI. */
+export function stemMethodLabel(method: StemGroupMethod): string {
+  switch (method) {
+    case "hpss":
+      return "HPSS";
+    case "ai":
+      return "AI stems";
+    case "nmf":
+      return "NMF";
+  }
+}
+
+export type FileSegment = {
+  /** Null for files that belong to no group. */
+  groupId: string | null;
+  fileIds: string[];
+};
+
+/**
+ * Split the open-file order into runs of adjacent files that share a group, so
+ * the canvas can wrap each run in one bracket. Members are inserted contiguously
+ * at split time; if anything ever separates them, each run brackets on its own
+ * rather than drawing a rail across unrelated files.
+ */
+export function getFileSegments(openFileIds: string[], stemGroupOfFile: Record<string, string>): FileSegment[] {
+  const segments: FileSegment[] = [];
+  for (const fileId of openFileIds) {
+    const groupId = stemGroupOfFile[fileId] ?? null;
+    const last = segments[segments.length - 1];
+    if (last && last.groupId === groupId && groupId !== null) {
+      last.fileIds.push(fileId);
+    } else if (last && last.groupId === null && groupId === null) {
+      last.fileIds.push(fileId);
+    } else {
+      segments.push({ groupId, fileIds: [fileId] });
+    }
+  }
+  return segments;
+}
+
+export const createStemGroupsSlice = (set: ZustandSet, get: ZustandGet): StemGroupsState => ({
+  stemGroups: {},
+  stemGroupOfFile: {},
+
+  createStemGroup: (group) => {
+    const id = nextStemGroupId();
+    set(
+      produce((state: State) => {
+        state.stemGroups[id] = { ...group, id, syncView: group.syncView ?? true };
+        for (const memberId of group.memberIds) {
+          state.stemGroupOfFile[memberId] = id;
+        }
+      }),
+    );
+    return id;
+  },
+
+  setStemGroupSyncView: (groupId, syncView) => {
+    set(
+      produce((state: State) => {
+        const group = state.stemGroups[groupId];
+        if (group) group.syncView = syncView;
+      }),
+    );
+  },
+
+  removeFileFromStemGroup: (fileId) => {
+    const groupId = get().stemGroupOfFile[fileId];
+    if (!groupId) return;
+    set(
+      produce((state: State) => {
+        delete state.stemGroupOfFile[fileId];
+        const group = state.stemGroups[groupId];
+        if (!group) return;
+        group.memberIds = group.memberIds.filter((id) => id !== fileId);
+        if (group.memberIds.length < 2) {
+          for (const id of group.memberIds) delete state.stemGroupOfFile[id];
+          delete state.stemGroups[groupId];
+        }
+      }),
+    );
+  },
+});

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -9,6 +9,7 @@ import type { FilesState } from "./files";
 import { ModulatorsState } from "./modulators";
 import type { LinkState } from "./link";
 import type { PresetsState } from "./presets";
+import type { StemGroupsState } from "./stem-groups";
 import type { StepsState } from "./steps";
 
 export type BrushColor = {
@@ -104,7 +105,8 @@ export type State = BrushState &
   AppState &
   PresetsState &
   StepsState &
-  LinkState & {
+  LinkState &
+  StemGroupsState & {
     setParameter: (key: ParameterKey, value: unknown, effectId?: string) => void;
     randomizationAmounts: Record<string, number>;
     setRandomizationAmount: (key: string, amount: number) => void;


### PR DESCRIPTION
Adds a third separation method that splits into an arbitrary number of parts, and links the parts from any split so they can be summed back into a new file.

## Why the linkage means something

HPSS masks the magnitude channels and leaves phase alone, and the masks sum to 1 — the parts genuinely add back up to what they were split from. NMF is built to preserve that property. So "merge these back together" isn't an approximation, and that's what makes tracking a split worth doing rather than just naming the files consistently.

## NMF (`gaborator-addon.cpp`)

Factorises the magnitude spectrogram as `V ≈ W·H` with KL-divergence multiplicative updates, then turns each component's reconstruction into a Wiener soft mask — the direct generalisation of HPSS's `h²/(h²+p²)` to K parts. Applied to the magnitude channels only, phase copied through untouched.

Two things specific to Gaborator:

- **It's multirate.** `bandLengths[b]` differs per band, so `V` isn't rectangular. The fit runs on a matrix built by resampling each band onto a shared normalised time grid (capped at 2048 frames), and masks are evaluated at each band's native rate by interpolating `H` back up. That also keeps the fit cheap without losing output resolution.
- **Channels are fitted together.** `W`/`H` are fitted once on the summed magnitude so component *k* is the same sound in left and right — per-channel fitting would desync them, which HPSS gets away with only because harmonic/percussive is semantically fixed.

Components come out ordered by spectral centroid (low→high reads naturally against the vertical spectrogram) and the PRNG is seeded, so a given seed reproduces a split. Pure C++, so unlike the ONNX path (macOS-only, `binding.gyp:31`) it works everywhere.

## Merge (`mergeSpectrograms`)

Sums spectrograms sharing a band layout. Two details that matter:

- **Complex sum, not magnitude sum.** Right after a split all parts share phase and magnitudes would add correctly by accident. The moment the transform effect touches one part its phase diverges and magnitude addition overlaps incoherently — too loud in the shared bins.
- **Phase stays unwrapped.** `analyze()` accumulates phase along time rather than wrapping it (`gaborator-addon.cpp:333-346`), and the transform effect scales that value directly. Handing back `atan2`'s `[-π, π]` would quietly change what a later stretch or pitch shift does, so the summed angle is re-expressed on the branch of whichever part contributed most. Parts that still share a phase come back with it bit-for-bit.

## Stem groups

`OpenFile` had no parent or group field — splits just spliced into `openFileIds` after their source, so adjacency and a shared name prefix were the entire relationship. A new store slice records what each split produced, with a reverse `fileId → groupId` index for the per-file lookups the UI does.

- **Colour**: members wear shades of one hue derived from the source path, instead of each hashing its own path. This is why stems currently read as unrelated files.
- **Bracket**: the canvas wraps each run of members in a rail with a group header carrying the label, the merge button, and the view-sync toggle.
- **Merge**: offered on the group header *and* on each member's header. It creates a new file and leaves the parts open. It reads each part's current painted state (not its analysed data), refuses to run when a part's length or resolution no longer lines up, and takes `magnitudeEnergy` from the file the split came from — no part's own total describes the sum, and Convolve normalises its IR against it.
- **View sync**: zoom and scroll follow each other across a group by default, toggleable per group. Those were copied once at split time and then drifted apart.
- **Lifecycle**: groups persist with their members and dissolve once fewer than two remain, including when a member is closed.

Merging a subset is supported by the underlying `mergeStems(fileIds)` action — for NMF you always end up wanting to fold two parts together — though only merge-all has UI so far.

## Incidental

- The three split paths now share placeholder/rollback helpers, which gives HPSS the error handling the AI path already had (it previously left orphaned placeholder files behind on failure).
- Fixes AI stems recording the *global* `minFreq`/`bandsPerOctave` rather than the values they were actually analysed at (`files.ts:809-810`).
- Corrects a stale comment claiming virtual files don't round-trip across sessions — they do, via their `managed://` sentinel and history dir.

## Testing

`src/main/lib/__tests__/separation.test.ts` — 13 cases against the real addon, on a spectrogram from the addon's own `analyze()` rather than a hand-built buffer:

- masks sum to 1 (parts reconstruct the input's magnitude), phase channels bit-identical, no part exceeds the input
- components ordered by centroid; two sources four octaves apart land in different parts
- reproducible per seed, different across seeds
- merge reconstructs both NMF and HPSS parts, and keeps phase on the unwrapped branch — with an assertion guarding the premise, so the test can't pass for the wrong reason if analysis ever starts wrapping
- antiphase parts cancel, proving the sum is complex rather than magnitude

`src/renderer/src/lib/__tests__/stem-groups.test.ts` — 14 cases driving the real slice through a minimal store: membership indexing, member removal, group dissolution, segment bracketing including a group split by an unrelated file, and colour derivation.

`npm run test:run` 171 passed / 3 skipped, `npm run test:addon` 20 passed, typecheck and lint clean.

## Not included

Group solo/mute and summed playback. Playback is single-file (one `Tone.Player` keyed off `activeFileId`) and there's no mix bus anywhere in the codebase, so that's a separate piece of work rather than an extension of this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_013fcrY5pgcyKEvrY3pM84ye)_